### PR TITLE
Added MenuButton.disabled(Bool) view modifier

### DIFF
--- a/Examples/PopoversXcodeApp/PopoversXcodeApp/ShowroomFiles/MenuView.swift
+++ b/Examples/PopoversXcodeApp/PopoversXcodeApp/ShowroomFiles/MenuView.swift
@@ -29,10 +29,7 @@ struct MenuView: View {
                 Templates.MenuButton(title: "Disabled button", systemImage: "xmark.circle") {
                     iconName = "xmark.circle"
                 }
-                .disabled(buttonDisabled) /// `true` by default
-//                Templates.MenuButton(title: "Toggle") {
-//                    buttonDisabled.toggle()
-//                }
+                .disabled(buttonDisabled) /// Disable this button.
             }
         } label: { fade in
             ExampleShowroomRow(color: UIColor(hex: 0xFF00AB)) {

--- a/Examples/PopoversXcodeApp/PopoversXcodeApp/ShowroomFiles/MenuView.swift
+++ b/Examples/PopoversXcodeApp/PopoversXcodeApp/ShowroomFiles/MenuView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct MenuView: View {
     @State var present = false
     @State var iconName = "list.bullet"
+    @State var buttonDisabled = true
 
     var body: some View {
         Templates.Menu {
@@ -25,6 +26,13 @@ struct MenuView: View {
                 Templates.MenuButton(title: "Change Icon To Bag", systemImage: "bag") {
                     iconName = "bag"
                 }
+                Templates.MenuButton(title: "Disabled button", systemImage: "xmark.circle") {
+                    iconName = "xmark.circle"
+                }
+                .disabled(buttonDisabled) /// `true` by default
+//                Templates.MenuButton(title: "Toggle") {
+//                    buttonDisabled.toggle()
+//                }
             }
         } label: { fade in
             ExampleShowroomRow(color: UIColor(hex: 0xFF00AB)) {

--- a/Sources/Templates/Menu/Menu.swift
+++ b/Sources/Templates/Menu/Menu.swift
@@ -175,6 +175,7 @@ public extension Templates {
         public let text: Text?
         public let image: Image?
         public let action: () -> Void
+        private var disabled: Bool = false
 
         /// A wrapper for `PopoverMenuItem` that mimics the system menu button style (title + image)
         public init(
@@ -207,24 +208,42 @@ public extension Templates {
             self.image = image
             self.action = action
         }
+        
+        var baseButton: some View {
+            HStack {
+                if let text = text {
+                    text
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                if let image = image {
+                    image
+                }
+            }
+            .accessibilityElement(children: .combine) /// Merge text and image into a single element.
+            .frame(maxWidth: .infinity)
+            .padding(EdgeInsets(top: 14, leading: 18, bottom: 14, trailing: 18))
+        }
 
         public var body: some View {
-            MenuItem(action) { pressed in
-                HStack {
-                    if let text = text {
-                        text
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-
-                    if let image = image {
-                        image
-                    }
-                }
-                .accessibilityElement(children: .combine) /// Merge text and image into a single element.
-                .frame(maxWidth: .infinity)
-                .padding(EdgeInsets(top: 14, leading: 18, bottom: 14, trailing: 18))
-                .background(pressed ? Templates.buttonHighlightColor : Color.clear) /// Add highlight effect when pressed.
+            /// Rendering outside of `MenuItem` when disabled because: 1) actions aren't run, 2) so tapping the disabled button won't dismiss the popover
+            if self.disabled {
+                baseButton
+                    .foregroundColor(.secondary) /// Add dimmed effect when disabled
+                    .opacity(0.9)
             }
+            else {
+                MenuItem(action) { pressed in
+                    baseButton
+                        .background(pressed ? Templates.buttonHighlightColor : Color.clear) /// Add highlight effect when pressed.
+                }
+            }
+        }
+      
+        public func disabled(_ disabled: Bool) -> Self {
+            var newView = self
+            newView.disabled = disabled
+            return newView
         }
     }
 

--- a/Sources/Templates/Menu/Menu.swift
+++ b/Sources/Templates/Menu/Menu.swift
@@ -240,7 +240,7 @@ public extension Templates {
             }
         }
       
-        public func disabled(_ disabled: Bool) -> Self {
+        public func disabled(_ disabled: Bool = true) -> Self {
             var newView = self
             newView.disabled = disabled
             return newView

--- a/Sources/Templates/Menu/Menu.swift
+++ b/Sources/Templates/Menu/Menu.swift
@@ -226,13 +226,12 @@ public extension Templates {
         }
 
         public var body: some View {
-            /// Rendering outside of `MenuItem` when disabled because: 1) actions aren't run, 2) so tapping the disabled button won't dismiss the popover
+            /// Rendering outside of `MenuItem` when disabled because: 1) actions aren't run, 2) so tapping the disabled button won't dismiss the popover.
             if self.disabled {
                 baseButton
                     .foregroundColor(.secondary) /// Add dimmed effect when disabled
                     .opacity(0.9)
-            }
-            else {
+            } else {
                 MenuItem(action) { pressed in
                     baseButton
                         .background(pressed ? Templates.buttonHighlightColor : Color.clear) /// Add highlight effect when pressed.
@@ -240,6 +239,7 @@ public extension Templates {
             }
         }
       
+        /// Disable this menu button.
         public func disabled(_ disabled: Bool = true) -> Self {
             var newView = self
             newView.disabled = disabled


### PR DESCRIPTION
This adds the `.disabled(Bool?)` View Modifier to mimic the built-in SwiftUI modifier: https://developer.apple.com/documentation/swiftui/form/disabled(_:)

When the `.disabled(true)` (or simply `.disabled()`) modifier is used:
- The button will have a "dimmed" appearance, similar to buttons which are disabled under the `.contextMenu` view modifier
- The button can't be highlighted by selecting it (either by tapping or a long press)
- The button's action closure won't be executed
- Tapping on a disabled button won't dismiss the popover

**Usage:**

```swift
Templates.Menu {
    Templates.DividedVStack {
        Templates.MenuButton(title: "Change Icon To List", systemImage: "list.bullet") {
            iconName = "list.bullet"
        }
        Templates.MenuButton(title: "Change Icon To Keyboard", systemImage: "keyboard") {
            iconName = "keyboard"
        }
        Templates.MenuButton(title: "Change Icon To Bag", systemImage: "bag") {
            iconName = "bag"
        }
        Templates.MenuButton(title: "Disabled button", systemImage: "xmark.circle") {
            iconName = "xmark.circle"
        }
        .disabled(buttonDisabled) /// `true` by default
    }
} label: { fade in
    ExampleShowroomRow(color: UIColor(hex: 0xFF00AB)) {
        HStack {
            ExampleImage(iconName, color: UIColor(hex: 0xFF00AB))

            Text("Popovers Menu")
                .fontWeight(.medium)
        }
    }
    .opacity(fade ? 0.5 : 1)
}
```

**Preview:**
![Simulator Screen Shot - iPod touch (7th generation) - 2022-06-23 at 18 46 41](https://user-images.githubusercontent.com/4109551/175432953-e9f38e49-4ea6-4c1d-9f55-46813e6ff648.png)

**Compare to native SwiftUI `Menu`:**
![Simulator Screen Shot - iPod touch (7th generation) - 2022-06-23 at 18 46 25](https://user-images.githubusercontent.com/4109551/175432996-cda2957e-699d-4ebe-b2ee-98740d388fa0.png)

