### PR TITLE
Code is for iOS only

### DIFF
--- a/Sources/Popover+Lifecycle.swift
+++ b/Sources/Popover+Lifecycle.swift
@@ -5,7 +5,7 @@
 //  Created by A. Zheng (github.com/aheze) on 1/4/22.
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
-
+#if os(iOS)
 import SwiftUI
 
 /**
@@ -192,3 +192,4 @@ extension UIView {
         }
     }
 }
+#endif

--- a/Sources/Popover+Positioning.swift
+++ b/Sources/Popover+Positioning.swift
@@ -5,7 +5,7 @@
 //  Created by A. Zheng (github.com/aheze) on 12/23/21.
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
-
+#if os(iOS)
 import SwiftUI
 
 /**
@@ -293,3 +293,4 @@ public extension Popover.Attributes.Position.Anchor {
         }
     }
 }
+#endif

--- a/Sources/Popover.swift
+++ b/Sources/Popover.swift
@@ -5,7 +5,7 @@
 //  Created by A. Zheng (github.com/aheze) on 12/23/21.
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
-
+#if os(iOS)
 import Combine
 import SwiftUI
 
@@ -599,3 +599,4 @@ extension Popover: Equatable {
         return lhs.id == rhs.id
     }
 }
+#endif

--- a/Sources/PopoverContainerView.swift
+++ b/Sources/PopoverContainerView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 /**
@@ -261,3 +262,4 @@ struct PopoverContainerView: View {
         return selectedPopoverOffset
     }
 }
+#endif

--- a/Sources/PopoverGestureContainer.swift
+++ b/Sources/PopoverGestureContainer.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 /// A hosting view for `PopoverContainerView` with tap filtering.
@@ -155,3 +156,4 @@ class PopoverGestureContainer: UIView {
         fatalError("[Popovers] - Create this view programmatically.")
     }
 }
+#endif

--- a/Sources/PopoverModel.swift
+++ b/Sources/PopoverModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import Combine
 import SwiftUI
 
@@ -122,3 +123,4 @@ class PopoverModel: ObservableObject {
         return frame ?? .zero
     }
 }
+#endif

--- a/Sources/PopoverUtilities.swift
+++ b/Sources/PopoverUtilities.swift
@@ -5,7 +5,7 @@
 //  Created by A. Zheng (github.com/aheze) on 12/23/21.
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
-
+#if os(iOS)
 import SwiftUI
 
 public extension UIView {
@@ -211,3 +211,4 @@ public extension View {
         }
     }
 }
+#endif

--- a/Sources/PopoverWindows.swift
+++ b/Sources/PopoverWindows.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 /**
@@ -135,3 +136,4 @@ extension EnvironmentValues {
         static var defaultValue: UIWindow? = nil
     }
 }
+#endif

--- a/Sources/Popovers.swift
+++ b/Sources/Popovers.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 /**
@@ -18,3 +19,4 @@ public enum Popovers {
     /// The delay after a bounds change before recalculating popover frames.
     public static var frameUpdateDelayAfterBoundsChange = CGFloat(0.6)
 }
+#endif

--- a/Sources/SwiftUI/FrameTag.swift
+++ b/Sources/SwiftUI/FrameTag.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 /**
@@ -86,3 +87,4 @@ public extension Optional where Wrapped: UIResponder {
         return .zero
     }
 }
+#endif

--- a/Sources/SwiftUI/Modifiers.swift
+++ b/Sources/SwiftUI/Modifiers.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import Combine
 import SwiftUI
 
@@ -376,3 +377,4 @@ public extension View {
         )
     }
 }
+#endif

--- a/Sources/SwiftUI/Readers.swift
+++ b/Sources/SwiftUI/Readers.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 /**
@@ -95,3 +96,4 @@ public struct WindowReader<Content: View>: View {
         }
     }
 }
+#endif

--- a/Sources/Templates/Alert.swift
+++ b/Sources/Templates/Alert.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 public extension Templates {
@@ -24,3 +25,4 @@ public extension Templates {
         }
     }
 }
+#endif

--- a/Sources/Templates/Blur.swift
+++ b/Sources/Templates/Blur.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 public extension Templates {
@@ -28,3 +29,4 @@ public extension Templates {
         }
     }
 }
+#endif

--- a/Sources/Templates/Container.swift
+++ b/Sources/Templates/Container.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 public extension Templates {
@@ -105,3 +106,4 @@ public extension Templates {
         }
     }
 }
+#endif

--- a/Sources/Templates/Extensions.swift
+++ b/Sources/Templates/Extensions.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 // MARK: - Shadows
@@ -341,3 +342,4 @@ extension ForEach: DynamicViewContentProvider where Content: View {
         return AnyView(content(data[dataIndex]))
     }
 }
+#endif

--- a/Sources/Templates/Menu/Menu+SwiftUI.swift
+++ b/Sources/Templates/Menu/Menu+SwiftUI.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 public extension Templates {
@@ -130,3 +131,4 @@ public extension Templates {
         }
     }
 }
+#endif

--- a/Sources/Templates/Menu/Menu+UIKit.swift
+++ b/Sources/Templates/Menu/Menu+UIKit.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import Combine
 import SwiftUI
 
@@ -176,3 +177,4 @@ public extension Templates.UIKitMenu {
         updatePresent(false)
     }
 }
+#endif

--- a/Sources/Templates/Menu/Menu.swift
+++ b/Sources/Templates/Menu/Menu.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 public extension Templates {
@@ -350,3 +351,4 @@ extension View {
         }
     }
 }
+#endif

--- a/Sources/Templates/Menu/Model/MenuGestureModel.swift
+++ b/Sources/Templates/Menu/Model/MenuGestureModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 extension Templates {
@@ -142,3 +143,4 @@ extension Templates {
         }
     }
 }
+#endif

--- a/Sources/Templates/Menu/Model/MenuModel.swift
+++ b/Sources/Templates/Menu/Model/MenuModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 extension Templates {
@@ -81,3 +82,4 @@ extension Templates {
         }
     }
 }
+#endif

--- a/Sources/Templates/Shadow.swift
+++ b/Sources/Templates/Shadow.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
     
+#if os(iOS)
 import SwiftUI
 
 public extension Templates {
@@ -31,3 +32,4 @@ public extension Templates {
         )
     }
 }
+#endif

--- a/Sources/Templates/Shapes.swift
+++ b/Sources/Templates/Shapes.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 public extension Templates {
@@ -207,3 +208,4 @@ public extension Templates {
         }
     }
 }
+#endif

--- a/Sources/Templates/Templates.swift
+++ b/Sources/Templates/Templates.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 /**
@@ -17,3 +18,4 @@ public enum Templates {
     /// Highlight color for the alert and menu buttons.
     public static var buttonHighlightColor = Color.secondary.opacity(0.2)
 }
+#endif

--- a/Sources/Templates/Views.swift
+++ b/Sources/Templates/Views.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 A. Zheng. All rights reserved.
 //
 
+#if os(iOS)
 import SwiftUI
 
 public extension Templates {
@@ -109,3 +110,4 @@ public extension Templates {
         }
     }
 }
+#endif


### PR DESCRIPTION
I thought this was a helpful fill-in for porting my macOS SwiftUI app to iOS, however I'm unable to include this SPM package in a project which builds for both macOS and iOS because of how SPM works. Specifying iOS in your Package.swift does not *limit* the build to to only iOS. Please let me know if you know a better way to accomplish this. Thanks