### PR TITLE
Support stateful popovers

### DIFF
--- a/Sources/PopoverGestureContainer.swift
+++ b/Sources/PopoverGestureContainer.swift
@@ -37,6 +37,8 @@ class PopoverGestureContainer: UIView {
         /// Store the bounds for later.
         previousBounds = bounds
     }
+    
+    private lazy var host: UIHostingController<AnyView> = UIHostingController(rootView: AnyView(PopoverContainerView(popoverModel: popoverModel)))
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
@@ -45,15 +47,13 @@ class PopoverGestureContainer: UIView {
         guard let window = window else { return }
 
         /// Create the SwiftUI view that contains all the popovers.
-        let popoverContainerView = PopoverContainerView(popoverModel: popoverModel)
-            .environment(\.window, window) /// Inject the window.
 
-        let hostingController = UIHostingController(rootView: popoverContainerView)
-        hostingController.view.frame = bounds
-        hostingController.view.backgroundColor = .clear
-        hostingController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        host.rootView = AnyView(host.rootView.environment(\.window, window)) // Inject the window.
+        host.view.frame = bounds
+        host.view.backgroundColor = .clear
+        host.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
-        addSubview(hostingController.view)
+        addSubview(host.view)
 
         /// Ensure the view is laid out so that SwiftUI animations don't stutter.
         setNeedsLayout()


### PR DESCRIPTION
Let's say I have a popover that looks like this:

```BasicView.swift
import Popovers
import SwiftUI

struct BasicView: View {
    @State var present = false

    var body: some View {
        ExampleRow(
            image: "square",
            title: "Basic",
            color: 0x00AEEF
        ) {
            present.toggle()
        }
        .popover(present: $present) {
            TimedRenderingView()
                .background(.thinMaterial)
        }

    }
    
    struct TimedRenderingView: View {
        @State private var data = ["Example"]
        let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
        
        var body: some View {
            VStack {
                ForEach(data, id: \.self) { line in
                    Text(line)
                }
            }
            .onReceive(timer) { _ in
                data = Array(repeating: "Example", count: .random(in: 1...10))
            }
        }
    }
}
```

Currently, once the popover is presented, it will never be updated, even as the `data` changes. This PR adds support for re-rendering the popover view when SwiftUI decides it's appropriate, such as when one or more of its state, binding, or environment properties change. This represents a partial fix for #72, specifically for cases where popover views maintain some kind of internal properties to signal the need for a re-render

This work was done as part of my day job at [Chariot Solutions, LLC](https://chariotsolutions.com) to help support projects for ourselves and our clients