### PR TITLE
Rename `UIKit` to `UIKitView`

### DIFF
--- a/Examples/PopoversExample.xcodeproj/project.pbxproj
+++ b/Examples/PopoversExample.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		3CA34FAC279533E300AC36DF /* AccessibilityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA34FAB279533E300AC36DF /* AccessibilityView.swift */; };
 		3CBD875E27755E45005BBA48 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBD875D27755E45005BBA48 /* App.swift */; };
 		3CBD876527755E50005BBA48 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBD875F27755E50005BBA48 /* ContentView.swift */; };
-		3CBD876627755E50005BBA48 /* UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBD876027755E50005BBA48 /* UIKit.swift */; };
 		3CBD876727755E50005BBA48 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBD876127755E50005BBA48 /* Utilities.swift */; };
 		3CBD876827755E50005BBA48 /* NavigationToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBD876227755E50005BBA48 /* NavigationToolbar.swift */; };
 		3CBD876927755E50005BBA48 /* Playground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBD876327755E50005BBA48 /* Playground.swift */; };
@@ -44,6 +43,7 @@
 		3CBD87AA27756277005BBA48 /* Popovers in Frameworks */ = {isa = PBXBuildFile; productRef = 3CBD87A927756277005BBA48 /* Popovers */; };
 		3CCA6CED27AF2287002D0091 /* Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCA6CEC27AF2287002D0091 /* Testing.swift */; };
 		3CCA6CEF27AF24A0002D0091 /* MenuComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCA6CEE27AF249F002D0091 /* MenuComparisonView.swift */; };
+		4A4C9F282AFBD2B500F309A1 /* UIKitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4C9F272AFBD2B500F309A1 /* UIKitView.swift */; };
 		CA04D305277B3488004E8FF6 /* PresentWithinSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA04D304277B3488004E8FF6 /* PresentWithinSheetView.swift */; };
 		CA6F682D2786F70700DF97E7 /* FormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F682C2786F70700DF97E7 /* FormView.swift */; };
 /* End PBXBuildFile section */
@@ -56,7 +56,6 @@
 		3CBD874C27755E19005BBA48 /* PopoversExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PopoversExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CBD875D27755E45005BBA48 /* App.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		3CBD875F27755E50005BBA48 /* ContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		3CBD876027755E50005BBA48 /* UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKit.swift; sourceTree = "<group>"; };
 		3CBD876127755E50005BBA48 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		3CBD876227755E50005BBA48 /* NavigationToolbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationToolbar.swift; sourceTree = "<group>"; };
 		3CBD876327755E50005BBA48 /* Playground.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Playground.swift; sourceTree = "<group>"; };
@@ -87,6 +86,7 @@
 		3CBD879A27755E5F005BBA48 /* PresentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentView.swift; sourceTree = "<group>"; };
 		3CCA6CEC27AF2287002D0091 /* Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Testing.swift; sourceTree = "<group>"; };
 		3CCA6CEE27AF249F002D0091 /* MenuComparisonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuComparisonView.swift; sourceTree = "<group>"; };
+		4A4C9F272AFBD2B500F309A1 /* UIKitView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitView.swift; sourceTree = "<group>"; };
 		CA04D304277B3488004E8FF6 /* PresentWithinSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentWithinSheetView.swift; sourceTree = "<group>"; };
 		CA6F682C2786F70700DF97E7 /* FormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -106,10 +106,10 @@
 		3C5DB8B82945335B00017ADE /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
-				3CBD876027755E50005BBA48 /* UIKit.swift */,
+				3CBD879927755E5F005BBA48 /* DismissView.swift */,
 				3CBD879A27755E5F005BBA48 /* PresentView.swift */,
 				3CBD879827755E5F005BBA48 /* ReplaceView.swift */,
-				3CBD879927755E5F005BBA48 /* DismissView.swift */,
+				4A4C9F272AFBD2B500F309A1 /* UIKitView.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -301,7 +301,7 @@
 				CA04D305277B3488004E8FF6 /* PresentWithinSheetView.swift in Sources */,
 				3CBD877D27755E57005BBA48 /* BasicView.swift in Sources */,
 				3CBD879527755E5B005BBA48 /* TutorialView.swift in Sources */,
-				3CBD876627755E50005BBA48 /* UIKit.swift in Sources */,
+				4A4C9F282AFBD2B500F309A1 /* UIKitView.swift in Sources */,
 				3CBD877E27755E57005BBA48 /* BackgroundView.swift in Sources */,
 				3CBD876A27755E50005BBA48 /* Showroom.swift in Sources */,
 				3CCA6CEF27AF24A0002D0091 /* MenuComparisonView.swift in Sources */,

--- a/Examples/PopoversExample/ContentView.swift
+++ b/Examples/PopoversExample/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
                 ) {
                     Playground()
                     Showroom()
-                    UIKit()
+                    UIKitView()
                     Testing()
 
                     Color.clear.frame(height: 40)

--- a/Examples/PopoversExample/UIKit/UIKitView.swift
+++ b/Examples/PopoversExample/UIKit/UIKitView.swift
@@ -1,5 +1,5 @@
 //
-//  UIKit.swift
+//  UIKitView.swift
 //  PopoversExample
 //
 //  Created by A. Zheng (github.com/aheze) on 12/23/21.
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-struct UIKit: View {
+struct UIKitView: View {
     var body: some View {
         Section(
             header:


### PR DESCRIPTION
This resolves a conflict with automatic resource name generation in Xcode 15.

Fixes #104