### PR TITLE
Create attribute changeLocationOnDismiss, which allows popover's location to be changed to its last location

### DIFF
--- a/Sources/Popover+Attributes.swift
+++ b/Sources/Popover+Attributes.swift
@@ -56,6 +56,9 @@ extension Popover {
         /// Prevent views underneath the popover from being pressed.
         public var blocksBackgroundTouches = false
         
+        /// Allows popover's location to be changed to its last location.
+        public var changeLocationOnDismiss = false
+        
         /// Frames that won't be blocked when `blocksBackgroundTouches` is turned on.
         public var blocksBackgroundTouchesAllowedFrames: () -> [CGRect] = { [] }
         

--- a/Sources/Popover+Calculations.swift
+++ b/Sources/Popover+Calculations.swift
@@ -103,6 +103,12 @@ public extension Popover {
             dismiss()
             return
         }
+        if
+            attributes.changeLocationOnDismiss
+        {
+            context.staticFrame = context.frame
+            return
+        }
 
         if case let .relative(popoverAnchors) = attributes.position {
             let frame = attributes.sourceFrame().inset(by: attributes.sourceFrameInset)

--- a/Sources/PopoverContainerView.swift
+++ b/Sources/PopoverContainerView.swift
@@ -217,6 +217,9 @@ struct PopoverContainerView: View {
                 applyVerticalOffset(dragDown: true)
             } else if popover.attributes.dismissal.mode.contains(.dragUp) {
                 applyVerticalOffset(dragDown: false)
+            } else if popover.attributes.changeLocationOnDismiss {
+                /// Popover can be dragged to any position, so don't apply any rubber banding and directly set its translation.
+                selectedPopoverOffset = translation
             } else {
                 selectedPopoverOffset = applyRubberBanding(to: popover, translation: translation)
             }


### PR DESCRIPTION
I added an attribute `changeLocationOnDismiss`, which allows the popover's location to be changed to the last location the user drags. There is no rubber banding, and when the user stops dragging, the popover's location changes and its static frame is updated.